### PR TITLE
Enhance portfolio site with live documentation

### DIFF
--- a/docs/sample.json
+++ b/docs/sample.json
@@ -1,0 +1,6 @@
+{
+  "id": "sample",
+  "title": "Sample Documentation",
+  "date": "2025-01-01",
+  "content": "This is a sample documentation entry. Edit me!"
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Portfolio</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <nav>
+    <ul>
+      <li><a href="#home">Home</a></li>
+      <li><a href="#docs">Documentation</a></li>
+      <li><a href="/download-cv" id="cv-link">Download CV</a></li>
+    </ul>
+  </nav>
+
+  <section id="home" class="fade">
+    <h1>My Portfolio</h1>
+    <div class="skills">
+      <div class="skill"><span>JavaScript</span><div class="bar"><div class="fill js"></div></div></div>
+      <div class="skill"><span>Node.js</span><div class="bar"><div class="fill node"></div></div></div>
+      <div class="skill"><span>CSS</span><div class="bar"><div class="fill css"></div></div></div>
+    </div>
+    <div class="portfolio">
+      <div class="portfolio-item">Project A</div>
+      <div class="portfolio-item">Project B</div>
+      <div class="portfolio-item">Project C</div>
+    </div>
+  </section>
+
+  <section id="docs" class="fade">
+    <h2>Documentation</h2>
+    <input type="text" id="search" placeholder="Search docs">
+    <div id="docs-list"></div>
+  </section>
+
+  <script src="scripts.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev & npx next-video sync -w",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "server": "node server.js"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",

--- a/public/cv.pdf
+++ b/public/cv.pdf
@@ -1,0 +1,21 @@
+%PDF-1.4
+1 0 obj<<>>endobj
+2 0 obj<<>>endobj
+3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 200 200]/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>endobj
+4 0 obj<</Length 44>>stream
+BT/F1 24 Tf 72 120 Td(Hello CV)Tj ET
+endstream
+endobj
+5 0 obj<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000020 00000 n 
+0000000030 00000 n 
+0000000177 00000 n 
+0000000272 00000 n 
+trailer<</Size 6/Root 1 0 R>>
+startxref
+341
+%%EOF

--- a/scripts.js
+++ b/scripts.js
@@ -1,0 +1,107 @@
+let isAuthenticated = false;
+let authPassword = "";
+
+async function fetchDocs() {
+  const res = await fetch('/api/docs');
+  const docs = await res.json();
+  const list = document.getElementById('docs-list');
+  list.innerHTML = '';
+  docs.forEach(doc => {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'doc fade';
+    wrapper.setAttribute('data-id', doc.id);
+    wrapper.innerHTML = `
+      <h3>${doc.title}</h3>
+      <small>${doc.date}</small>
+      <div class="content">${doc.content}</div>
+      <button class="edit-btn">Edit</button>
+    `;
+    list.appendChild(wrapper);
+  });
+  attachDocEvents();
+  observeFades();
+}
+
+function observeFades() {
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('visible');
+        if (entry.target.id === 'home') {
+          const fills = document.querySelectorAll('.fill');
+          fills.forEach((el, idx) => {
+            const widths = ['90%', '80%', '70%'];
+            el.style.width = widths[idx] || '60%';
+          });
+        }
+      }
+    });
+  }, { threshold: 0.1 });
+  document.querySelectorAll('.fade').forEach(el => observer.observe(el));
+}
+
+function attachDocEvents() {
+  document.querySelectorAll('.edit-btn').forEach(btn => {
+    if (isAuthenticated) btn.style.display = 'block';
+    btn.addEventListener('click', async (e) => {
+      const docEl = e.target.closest('.doc');
+      const id = docEl.dataset.id;
+      if (!isAuthenticated) {
+        const password = prompt('Enter edit password');
+        if (!password) return;
+        const authRes = await fetch('/api/auth', {
+          method: 'POST',
+          headers: {'Content-Type':'application/json'},
+          body: JSON.stringify({ password })
+        });
+        if (authRes.ok) {
+          isAuthenticated = true;
+          authPassword = password;
+          document.querySelectorAll('.edit-btn').forEach(b => b.style.display = 'block');
+        } else {
+          alert('Wrong password');
+          return;
+        }
+      }
+      if (!docEl.classList.contains('editing')) {
+        const contentDiv = docEl.querySelector('.content');
+        const text = contentDiv.innerText;
+        contentDiv.innerHTML = `<textarea>${text}</textarea>`;
+        e.target.textContent = 'Save';
+        docEl.classList.add('editing');
+      } else {
+        const text = docEl.querySelector('textarea').value;
+        const title = docEl.querySelector('h3').innerText;
+        const date = new Date().toISOString().split('T')[0];
+        const saveRes = await fetch(`/api/docs/${id}`, {
+          method: 'POST',
+          headers: {'Content-Type':'application/json'},
+          body: JSON.stringify({ password: authPassword, content: text, title, date })
+        });
+        if (saveRes.ok) {
+          docEl.querySelector('.content').innerHTML = text;
+          docEl.querySelector('small').innerText = date;
+          e.target.textContent = 'Edit';
+          docEl.classList.remove('editing');
+        } else {
+          alert('Failed to save');
+        }
+      }
+    });
+  });
+}
+
+document.getElementById('search').addEventListener('input', (e) => {
+  const term = e.target.value.toLowerCase();
+  document.querySelectorAll('#docs-list .doc').forEach(doc => {
+    const title = doc.querySelector('h3').innerText.toLowerCase();
+    doc.style.display = title.includes(term) ? 'block' : 'none';
+  });
+});
+
+window.addEventListener('DOMContentLoaded', () => {
+  fetchDocs();
+  observeFades();
+});
+
+setInterval(fetchDocs, 5000);

--- a/server.js
+++ b/server.js
@@ -1,0 +1,99 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const { URL } = require('url');
+
+const PORT = process.env.PORT || 3000;
+const PASSWORD = process.env.DOCS_PASSWORD || 'changeme';
+const docsDir = path.join(__dirname, 'docs');
+
+function sendJSON(res, status, data) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(data));
+}
+
+function sanitize(str) {
+  return str.replace(/<script.*?>.*?<\/script>/gi, '');
+}
+
+const server = http.createServer((req, res) => {
+  const parsedUrl = new URL(req.url, `http://${req.headers.host}`);
+  const pathname = parsedUrl.pathname;
+
+  if (req.method === 'GET' && pathname === '/api/docs') {
+    const files = fs.readdirSync(docsDir).filter(f => f.endsWith('.json'));
+    const docs = files.map(f => JSON.parse(fs.readFileSync(path.join(docsDir, f), 'utf8')));
+    return sendJSON(res, 200, docs);
+  }
+
+  if (req.method === 'POST' && pathname === '/api/auth') {
+    let body = '';
+    req.on('data', chunk => body += chunk);
+    req.on('end', () => {
+      const { password } = JSON.parse(body || '{}');
+      if (password === PASSWORD) return sendJSON(res, 200, { success: true });
+      sendJSON(res, 401, { success: false });
+    });
+    return;
+  }
+
+  const docMatch = pathname.match(/^\/api\/docs\/([^\/]+)$/);
+  if (docMatch && req.method === 'POST') {
+    const id = docMatch[1];
+    let body = '';
+    req.on('data', chunk => body += chunk);
+    req.on('end', () => {
+      const { password, content, title, date } = JSON.parse(body || '{}');
+      if (password !== PASSWORD) return sendJSON(res, 401, { success: false });
+      const safeContent = sanitize(content || '');
+      const doc = { id, title, date, content: safeContent };
+      fs.writeFileSync(path.join(docsDir, `${id}.json`), JSON.stringify(doc, null, 2));
+      sendJSON(res, 200, { success: true, doc });
+    });
+    return;
+  }
+
+  if (req.method === 'GET' && pathname === '/download-cv') {
+    const cvPath = path.join(__dirname, 'public', 'cv.pdf');
+    if (fs.existsSync(cvPath)) {
+      res.writeHead(200, {
+        'Content-Type': 'application/pdf',
+        'Content-Disposition': 'attachment; filename="cv.pdf"'
+      });
+      fs.createReadStream(cvPath).pipe(res);
+    } else {
+      res.writeHead(404);
+      res.end('CV not found');
+    }
+    return;
+  }
+
+  // static files
+  let filePath = path.join(__dirname, pathname === '/' ? 'index.html' : pathname);
+  if (filePath.indexOf(__dirname) !== 0) {
+    res.writeHead(403);
+    res.end('Forbidden');
+    return;
+  }
+  const ext = path.extname(filePath).toLowerCase();
+  const map = {
+    '.html': 'text/html',
+    '.css': 'text/css',
+    '.js': 'application/javascript',
+    '.json': 'application/json',
+    '.png': 'image/png',
+    '.svg': 'image/svg+xml',
+    '.pdf': 'application/pdf'
+  };
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.writeHead(404);
+      res.end('Not found');
+    } else {
+      res.writeHead(200, { 'Content-Type': map[ext] || 'text/plain' });
+      res.end(data);
+    }
+  });
+});
+
+server.listen(PORT, () => console.log(`Server running on ${PORT}`));

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,110 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  background: #111;
+  color: #fff;
+  scroll-behavior: smooth;
+}
+nav {
+  position: fixed;
+  top: 0;
+  width: 100%;
+  background: #222;
+  padding: 10px 0;
+  z-index: 1000;
+}
+nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+}
+nav a, nav button {
+  color: #fff;
+  text-decoration: none;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+}
+section {
+  padding: 80px 20px;
+  min-height: 100vh;
+}
+.fade {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+.fade.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+.skills .bar {
+  background: #444;
+  height: 8px;
+  border-radius: 4px;
+  overflow: hidden;
+  margin-bottom: 10px;
+}
+.skills .fill {
+  height: 100%;
+  width: 0;
+  transition: width 2s;
+}
+.fill.js {
+  background: #f7df1e;
+}
+.fill.node {
+  background: #68a063;
+}
+.fill.css {
+  background: #264de4;
+}
+.doc {
+  margin-bottom: 1rem;
+  padding: 1rem;
+  background: #1e1e1e;
+  border-radius: 8px;
+  position: relative;
+}
+.doc h3 {
+  margin-top: 0;
+}
+.doc .edit-btn {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: none;
+}
+.doc.editing textarea {
+  width: 100%;
+  min-height: 100px;
+}
+@media (max-width: 600px) {
+  nav ul {
+    flex-direction: column;
+    align-items: center;
+  }
+  section {
+    padding-top: 100px;
+  }
+}
+.portfolio {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 20px;
+}
+.portfolio-item {
+  background: #1e1e1e;
+  padding: 1rem;
+  border-radius: 8px;
+  transition: transform 0.3s, box-shadow 0.3s;
+}
+.portfolio-item:hover {
+  transform: scale(1.05);
+  box-shadow: 0 0 10px rgba(0,0,0,0.5);
+}


### PR DESCRIPTION
## Summary
- Add static portfolio layout with animated skills, portfolio items, and documentation section with search.
- Implement client-side editing with password-gated Save and automatic refresh for docs.
- Provide Node backend for CV download, authentication, and documentation read/write.

## Testing
- `node server.js` (starts server)
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895453043a08333a0196d0350ff2b4a